### PR TITLE
Disable -Werror

### DIFF
--- a/c-examples/Makefile.in
+++ b/c-examples/Makefile.in
@@ -1,7 +1,7 @@
 FLTKCONFIG=@FLTKCONFIG@
-CXX = $(shell $(FLTKCONFIG) --cxx) $(shell $(FLTKCONFIG) --cxxflags) -Wall -Werror -DINTERNAL_LINKAGE -g -Icpp
+CXX = $(shell $(FLTKCONFIG) --cxx) $(shell $(FLTKCONFIG) --cxxflags) -Wall -DINTERNAL_LINKAGE -g -Icpp
 LD = $(CXX) -shared
-CC = $(shell $(FLTKCONFIG) --cc) $(shell $(FLTKCONFIG) --cflags) -Wall -Werror -g -I../c-src -I../ -I./
+CC = $(shell $(FLTKCONFIG) --cc) $(shell $(FLTKCONFIG) --cflags) -Wall -g -I../c-src -I../ -I./
 CXXLDFLAGS = @FLTKCONFIGCOMMAND@
 ifeq '$(OS)' "Windows_NT"
 EXEEXT = .exe

--- a/c-src/Makefile.in
+++ b/c-src/Makefile.in
@@ -1,5 +1,5 @@
 FLTKCONFIG=@FLTKCONFIG@
-CXX = $(shell $(FLTKCONFIG) --cxx) $(shell $(FLTKCONFIG) --cxxflags) -Wall -Werror -DINTERNAL_LINKAGE -g -Icpp -I../
+CXX = $(shell $(FLTKCONFIG) --cxx) $(shell $(FLTKCONFIG) --cxxflags) -Wall -DINTERNAL_LINKAGE -g -Icpp -I../
 CXXSHARED = $(CXX)
 CXXSTATIC = $(CXX) -static
 


### PR DESCRIPTION
It's hard to support -Werror with different compiler versions and host
configurations in use on various machines. Therefore, it's better to
disable -Werror. If required, one could enable -Werror with a new
configure flag.