### PR TITLE
Expose FLInputType constructors

### DIFF
--- a/src/Graphics/UI/FLTK/LowLevel/Input.chs
+++ b/src/Graphics/UI/FLTK/LowLevel/Input.chs
@@ -2,7 +2,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Graphics.UI.FLTK.LowLevel.Input
     (
-     FlInputType,
+     FlInputType(..),
      -- * Constructor
      inputNew
      -- * Hierarchy


### PR DESCRIPTION
I think we need this to use all the different Input widgets.