### PR TITLE
Add missing Fl_Tile_resize

### DIFF
--- a/c-src/Fl_TileC.cpp
+++ b/c-src/Fl_TileC.cpp
@@ -303,6 +303,9 @@ EXPORT {
   FL_EXPORT_C(void,Fl_Tile_add_resizable)(fl_Tile tile,fl_Widget o){
     return (static_cast<Fl_Tile*>(tile))->add_resizable(*(static_cast<Fl_Widget*>(o)));
   }
+  FL_EXPORT_C(void,Fl_Tile_resize)(fl_Tile tile, int x, int y, int w, int h){
+    return (static_cast<Fl_Tile*>(tile))->resize(x, y, w, h);
+  }
   FL_EXPORT_C(void,Fl_Tile_init_sizes)(fl_Tile tile){
     (static_cast<Fl_Tile*>(tile))->init_sizes();
   }


### PR DESCRIPTION
While i was trying to get fltkhs work in GHCi, i got stuck with undefined reference to `Fl_Tile_resize` function. It turns out that function is nowhere defined, but its imported in `Tile.chs`.

Weirdly only GHCi complained about missing symbol while GHC worked fine without that symbol.