### PR TITLE
Windows ghci fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
 
 PROJECT(fltkc)
+
+# CMake doesn't like backslashes in path
+STRING(REGEX REPLACE "\\\\" "/" FLTK_HOME ${FLTK_HOME}) 
+
 if(EXISTS "${FLTK_HOME}/lib/libfltk_z.a")
   SET(FLTK_Z "${FLTK_HOME}/lib/libfltk_z.a")
 else()
@@ -22,9 +26,32 @@ else()
   SET(FLTK_PNG "${HAVE_PNG}")
 endif()
 
-SET(FLTKCONFIGCOMMAND "${FLTK_HOME}/lib/libfltk.a ${FLTK_HOME}/lib/libfltk_gl.a ${FLTK_HOME}/lib/libfltk_images.a ${FLTK_PNG} ${FLTK_JPEG} ${FLTK_Z} ${FLTK_HOME}/lib/libfltk_forms.a")
-SET(FLTKCONFIGCOMMAND "${FLTKCONFIGCOMMAND} -mwindows -lglu32 -lopengl32 -lole32 -luuid -lcomctl32")
-MESSAGE("${FLTKCONFIGCOMMAND}")
+
+SET(FLTKLINKFLAGS "-Wl,-Bstatic")
+SET(FLTKLINKFLAGS "${FLTKLINKFLAGS} -lfltk.a -lfltk_gl -lfltk_images.a ${FLTK_PNG} ${FLTK_JPEG} ${FLTK_Z} -lfltk_forms")
+SET(FLTKLINKFLAGS "${FLTKLINKFLAGS} -Wl,-Bdynamic")
+
+# target_link_libraries doesn't accept libraries as absolute path and
+# find_library usually returns path to import library instead static one
+# so replace any string in form of 'c:/dev/lib/libfoo.dll.a' with '-lfoo'
+STRING(REGEX REPLACE "[^ ]*/lib" "-l" FLTKLINKFLAGS ${FLTKLINKFLAGS})
+STRING(REGEX REPLACE "\\.dll\\.a|\\.a" "" FLTKLINKFLAGS ${FLTKLINKFLAGS})
+
+SET(FLTKLINKFLAGS "${FLTKLINKFLAGS} -lglu32 -lopengl32 -lole32 -luuid -lcomctl32 -lComdlg32 -static-libstdc++ -static-libgcc")
+
+# Newer versions of MinGW come with libwinpthread which gets linked dynamicaly by default
+find_library (HAVE_PTHREAD pthread)
+IF(HAVE_PTHREAD)
+	SET(FLTKLINKFLAGS "${FLTKLINKFLAGS} -Wl,-Bstatic,-lstdc++,-lpthread,-Bdynamic")
+else()
+	SET(FLTKLINKFLAGS "${FLTKLINKFLAGS} -Wl,-Bstatic,-lstdc++,-Bdynamic")
+endif()
+
+
+MESSAGE(STATUS "FLTKLINKFLAGS: ${FLTKLINKFLAGS}")
+
+SET(FLTKCONFIGCOMMAND "-Wl,-Bstatic,-whole-archive,-lfltkc,-no-whole-archive,-Bdynamic ${FLTKLINKFLAGS}")
+
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/fltkhs.buildinfo.in
                ${CMAKE_CURRENT_SOURCE_DIR}/fltkhs.buildinfo)
 FIND_PACKAGE(OpenGL REQUIRED)

--- a/c-src/CMakeLists.txt
+++ b/c-src/CMakeLists.txt
@@ -99,16 +99,26 @@ SET(SourceFiles
 	Fl_WizardC.cpp
   )
 
-ADD_DEFINITIONS("${CXX_FLAGS} -mwindows -DWIN32 -DUSE_OPENGL32 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -c -Wall -DINTERNAL_LINKAGE -g -Icpp -I\"${FLTK_HOME}\"")
+ADD_DEFINITIONS("${CXX_FLAGS} -DWIN32 -DUSE_OPENGL32 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -c -Wall -DINTERNAL_LINKAGE -g -Icpp -I\"${FLTK_HOME}/include\"")
 
 MESSAGE(STATUS ${CXX_FLAGS})
-ADD_LIBRARY(fltkc ${SourceFiles})
 
-set_target_properties(fltkc PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../c-lib)
+# first build object library so that we can reuse same objects for both static and shared library
+ADD_LIBRARY(fltkc_obj OBJECT ${SourceFiles})
 
-add_custom_command(TARGET fltkc PRE_LINK
-                   COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_SOURCE_DIR}/CMakeCopyObjectFiles.txt
-                   )
+ADD_LIBRARY(fltkc SHARED $<TARGET_OBJECTS:fltkc_obj>)
+
+target_link_libraries(fltkc ${FLTKLINKFLAGS} -L${FLTK_HOME}/lib)
+
+set_target_properties(fltkc PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../c-lib
+                                       RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../c-lib)
+
+
+ADD_LIBRARY(fltkc_static STATIC $<TARGET_OBJECTS:fltkc_obj>)
+set_target_properties(fltkc_static PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../c-lib
+                                              OUTPUT_NAME fltkc)
+
+
 set_directory_properties(PROPERTIES
                          ADDITIONAL_MAKE_CLEAN_FILES "${CMAKE_CURRENT_SOURCE_DIR}/../c-lib;
                                                       ${CMAKE_CURRENT_SOURCE_DIR}/../static_object_files;

--- a/configure.ac
+++ b/configure.ac
@@ -29,7 +29,7 @@ AC_CHECK_LIB([fltk_forms],
              FormsFlag='--use-forms',
              FormsFlag='')
 
-AC_SUBST(FLTKCONFIGCOMMAND,`fltk-config --ldstaticflags $GlFlag $ImagesFlag $CairoFlag $FormsFlag`)
+AC_SUBST(FLTKCONFIGCOMMAND,"$(fltk-config --ldstaticflags $GlFlag $ImagesFlag $CairoFlag $FormsFlag) -lstdc++")
 AC_SUBST(FLTK_HOME,`fltk-config --includedir`)
 # Checks for typedefs, structures, and compiler characteristics.
 AC_TYPE_SIZE_T

--- a/fltkhs.buildinfo.in
+++ b/fltkhs.buildinfo.in
@@ -1,2 +1,2 @@
-ld-options: @FLTKCONFIGCOMMAND@ -lstdc++
+ld-options: @FLTKCONFIGCOMMAND@
 include-dirs: @FLTK_HOME@

--- a/fltkhs.cabal
+++ b/fltkhs.cabal
@@ -125,7 +125,9 @@ Executable fltkhs-fluidtohs
     mtl
   default-language: Haskell2010
   ghc-Options: -Wall -threaded -fcontext-stack=300
-  if !os(darwin)
+  if os(windows)
+   ghc-Options: -optl-mwindows
+  if !os(darwin) && !os(windows)
     ghc-Options: -pgml g++ "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc" "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
 Flag FastCompile
@@ -144,7 +146,9 @@ Executable fltkhs-pack
   ghc-Options: -Wall -threaded -fcontext-stack=300
   if impl(ghc >= 7.10) && flag(FastCompile)
      ghc-Options: -fno-specialise -fmax-simplifier-iterations=0 -fsimplifier-phases=0
-  if !os(darwin)
+  if os(windows)
+   ghc-Options: -optl-mwindows
+  if !os(darwin) && !os(windows)
     ghc-Options: -pgml g++ "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc" "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
 Executable fltkhs-tile
@@ -158,7 +162,9 @@ Executable fltkhs-tile
   ghc-Options: -Wall -threaded -fcontext-stack=300
   if impl(ghc >= 7.10) && flag(FastCompile)
      ghc-Options: -fno-specialise -fmax-simplifier-iterations=0 -fsimplifier-phases=0
-  if !os(darwin)
+  if os(windows)
+   ghc-Options: -optl-mwindows
+  if !os(darwin) && !os(windows)
     ghc-Options: -pgml g++ "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc" "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
 Executable fltkhs-nativefilechooser-simple-app
@@ -172,7 +178,9 @@ Executable fltkhs-nativefilechooser-simple-app
   ghc-Options: -Wall -threaded -fcontext-stack=300
   if impl(ghc >= 7.10) && flag(FastCompile)
      ghc-Options: -fno-specialise -fmax-simplifier-iterations=0 -fsimplifier-phases=0
-  if !os(darwin)
+  if os(windows)
+   ghc-Options: -optl-mwindows
+  if !os(darwin) && !os(windows)
     ghc-Options: -pgml g++ "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc" "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
 Executable fltkhs-table-as-container
@@ -185,7 +193,9 @@ Executable fltkhs-table-as-container
   ghc-Options: -Wall -threaded -fcontext-stack=300
   if impl(ghc >= 7.10) && flag(FastCompile)
      ghc-Options: -fno-specialise -fmax-simplifier-iterations=0 -fsimplifier-phases=0
-  if !os(darwin)
+  if os(windows)
+   ghc-Options: -optl-mwindows
+  if !os(darwin) && !os(windows)
     ghc-Options: -pgml g++ "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc" "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
 Executable fltkhs-texteditor-simple
@@ -198,7 +208,9 @@ Executable fltkhs-texteditor-simple
   ghc-Options: -Wall -threaded -fcontext-stack=300
   if impl(ghc >= 7.10) && flag(FastCompile)
      ghc-Options: -fno-specialise -fmax-simplifier-iterations=0 -fsimplifier-phases=0
-  if !os(darwin)
+  if os(windows)
+   ghc-Options: -optl-mwindows
+  if !os(darwin) && !os(windows)
     ghc-Options: -pgml g++ "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc" "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
 Executable fltkhs-textdisplay-with-colors
@@ -211,7 +223,9 @@ Executable fltkhs-textdisplay-with-colors
   ghc-Options: -Wall -threaded -fcontext-stack=300
   if impl(ghc >= 7.10) && flag(FastCompile)
      ghc-Options: -fno-specialise -fmax-simplifier-iterations=0 -fsimplifier-phases=0
-  if !os(darwin)
+  if os(windows)
+   ghc-Options: -optl-mwindows
+  if !os(darwin) && !os(windows)
     ghc-Options: -pgml g++ "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc" "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
 Executable fltkhs-doublebuffer
@@ -224,7 +238,9 @@ Executable fltkhs-doublebuffer
   ghc-Options: -Wall -threaded -fcontext-stack=300
   if impl(ghc >= 7.10) && flag(FastCompile)
      ghc-Options: -fno-specialise -fmax-simplifier-iterations=0 -fsimplifier-phases=0
-  if !os(darwin)
+  if os(windows)
+   ghc-Options: -optl-mwindows
+  if !os(darwin) && !os(windows)
     ghc-Options: -pgml g++ "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc" "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
 Executable fltkhs-make-tree
@@ -237,7 +253,9 @@ Executable fltkhs-make-tree
   ghc-Options: -Wall -threaded -fcontext-stack=300
   if impl(ghc >= 7.10) && flag(FastCompile)
      ghc-Options: -fno-specialise -fmax-simplifier-iterations=0 -fsimplifier-phases=0
-  if !os(darwin)
+  if os(windows)
+   ghc-Options: -optl-mwindows
+  if !os(darwin) && !os(windows)
     ghc-Options: -pgml g++ "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc" "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
 Executable fltkhs-tree-simple
@@ -250,7 +268,9 @@ Executable fltkhs-tree-simple
   ghc-Options: -Wall -threaded -fcontext-stack=300
   if impl(ghc >= 7.10) && flag(FastCompile)
      ghc-Options: -fno-specialise -fmax-simplifier-iterations=0 -fsimplifier-phases=0
-  if !os(darwin)
+  if os(windows)
+   ghc-Options: -optl-mwindows
+  if !os(darwin) && !os(windows)
     ghc-Options: -pgml g++ "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc" "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
 Executable fltkhs-table-spreadsheet-with-keyboard-nav
@@ -263,7 +283,9 @@ Executable fltkhs-table-spreadsheet-with-keyboard-nav
   ghc-Options: -Wall -threaded -fcontext-stack=300
   if impl(ghc >= 7.10) && flag(FastCompile)
      ghc-Options: -fno-specialise -fmax-simplifier-iterations=0 -fsimplifier-phases=0
-  if !os(darwin)
+  if os(windows)
+   ghc-Options: -optl-mwindows
+  if !os(darwin) && !os(windows)
     ghc-Options: -pgml g++ "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc" "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
 Executable fltkhs-test_call
@@ -276,7 +298,9 @@ Executable fltkhs-test_call
   ghc-Options: -Wall -threaded -fcontext-stack=300
   if impl(ghc >= 7.10) && flag(FastCompile)
      ghc-Options: -fno-specialise -fmax-simplifier-iterations=0 -fsimplifier-phases=0
-  if !os(darwin)
+  if os(windows)
+   ghc-Options: -optl-mwindows
+  if !os(darwin) && !os(windows)
     ghc-Options: -pgml g++ "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc" "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
 Executable fltkhs-buttons
@@ -289,7 +313,9 @@ Executable fltkhs-buttons
   ghc-Options: -Wall -threaded -fcontext-stack=300
   if impl(ghc >= 7.10) && flag(FastCompile)
      ghc-Options: -fno-specialise -fmax-simplifier-iterations=0 -fsimplifier-phases=0
-  if !os(darwin)
+  if os(windows)
+   ghc-Options: -optl-mwindows
+  if !os(darwin) && !os(windows)
     ghc-Options: -pgml g++ "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc" "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
 Executable fltkhs-table-simple
@@ -302,7 +328,9 @@ Executable fltkhs-table-simple
   ghc-Options: -Wall -threaded -fcontext-stack=300
   if impl(ghc >= 7.10) && flag(FastCompile)
      ghc-Options: -fno-specialise -fmax-simplifier-iterations=0 -fsimplifier-phases=0
-  if !os(darwin)
+  if os(windows)
+   ghc-Options: -optl-mwindows
+  if !os(darwin) && !os(windows)
     ghc-Options: -pgml g++ "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc" "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
 Executable fltkhs-table-sort
@@ -316,7 +344,9 @@ Executable fltkhs-table-sort
   ghc-Options: -Wall -threaded -fcontext-stack=300
   if impl(ghc >= 7.10) && flag(FastCompile)
      ghc-Options: -fno-specialise -fmax-simplifier-iterations=0 -fsimplifier-phases=0
-  if !os(darwin)
+  if os(windows)
+   ghc-Options: -optl-mwindows
+  if !os(darwin) && !os(windows)
     ghc-Options: -pgml g++ "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc" "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
 Executable fltkhs-arc
@@ -329,7 +359,9 @@ Executable fltkhs-arc
   ghc-Options: -Wall -threaded -fcontext-stack=300
   if impl(ghc >= 7.10) && flag(FastCompile)
      ghc-Options: -fno-specialise -fmax-simplifier-iterations=0 -fsimplifier-phases=0
-  if !os(darwin)
+  if os(windows)
+   ghc-Options: -optl-mwindows
+  if !os(darwin) && !os(windows)
     ghc-Options: -pgml g++ "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc" "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
 Executable fltkhs-bitmap
@@ -342,7 +374,9 @@ Executable fltkhs-bitmap
   ghc-Options: -Wall -threaded -fcontext-stack=300
   if impl(ghc >= 7.10) && flag(FastCompile)
      ghc-Options: -fno-specialise -fmax-simplifier-iterations=0 -fsimplifier-phases=0
-  if !os(darwin)
+  if os(windows)
+   ghc-Options: -optl-mwindows
+  if !os(darwin) && !os(windows)
     ghc-Options: -pgml g++ "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc" "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
 Executable fltkhs-boxtype
@@ -355,7 +389,9 @@ Executable fltkhs-boxtype
   ghc-Options: -Wall -threaded -fcontext-stack=300
   if impl(ghc >= 7.10) && flag(FastCompile)
      ghc-Options: -fno-specialise -fmax-simplifier-iterations=0 -fsimplifier-phases=0
-  if !os(darwin)
+  if os(windows)
+   ghc-Options: -optl-mwindows
+  if !os(darwin) && !os(windows)
     ghc-Options: -pgml g++ "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc" "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
 Executable fltkhs-browser
@@ -369,7 +405,9 @@ Executable fltkhs-browser
   ghc-Options: -Wall -threaded -fcontext-stack=300
   if impl(ghc >= 7.10) && flag(FastCompile)
      ghc-Options: -fno-specialise -fmax-simplifier-iterations=0 -fsimplifier-phases=0
-  if !os(darwin)
+  if os(windows)
+   ghc-Options: -optl-mwindows
+  if !os(darwin) && !os(windows)
     ghc-Options: -pgml g++ "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc" "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
 Executable fltkhs-clock
@@ -383,5 +421,7 @@ Executable fltkhs-clock
   ghc-Options: -Wall -threaded -fcontext-stack=300
   if impl(ghc >= 7.10) && flag(FastCompile)
      ghc-Options: -fno-specialise -fmax-simplifier-iterations=0 -fsimplifier-phases=0
-  if !os(darwin)
+  if os(windows)
+   ghc-Options: -optl-mwindows
+  if !os(darwin) && !os(windows)
     ghc-Options: -pgml g++ "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc" "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"


### PR DESCRIPTION
With this set of fixes fltkhs now works in GHCi on Windows. Tested on Windows 10 32-bit under MSYS2.

I modified build system so that both static and shared version of fltkc is being built. GHCi will use shared version while programs compiled with GHC will have everything linked statically and should have no external DLL dependencies.