### PR TITLE
Support ghc-8.0.2

### DIFF
--- a/fltkhs.cabal
+++ b/fltkhs.cabal
@@ -135,7 +135,9 @@ library
 custom-setup
   setup-depends:
     base >= 4.5 && < 4.11,
-    Cabal < 1.25
+    Cabal < 1.25,
+    filepath,
+    directory
 
 Executable fltkhs-fluidtohs
   Main-Is: Main.hs


### PR DESCRIPTION
Compilation failed using latest Haskell Platform 8.0.2, which uses ghc-8.0.2.