### PR TITLE
Support older fltk-1.3.3

### DIFF
--- a/c-src/Fl_C.cpp
+++ b/c-src/Fl_C.cpp
@@ -594,6 +594,7 @@ EXPORT {
     Fl_Widget* refPtr = &ref;
     Fl::release_widget_pointer(refPtr);
   }
+#if FL_API_VERSION == 10304
   FL_EXPORT_C(void,Fl_set_box_color)(Fl_Color c) {
     Fl::set_box_color(c);
   }
@@ -618,6 +619,8 @@ EXPORT {
   FL_EXPORT_C(const char*,Fl_local_shift)(){
     return fl_local_shift;
   }
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/c-src/Fl_C.h
+++ b/c-src/Fl_C.h
@@ -257,6 +257,7 @@ EXPORT {
   FL_EXPORT_C(void              ,Fl_release_widget_pointer)(fl_Widget w);
   FL_EXPORT_C(void              ,Fl_clear_widget_pointer)(fl_Widget w);
   FL_EXPORT_C(void              ,Fl_clear_widget_pointer)(fl_Widget w);
+#if FL_API_VERSION == 10304
   FL_EXPORT_C(void              ,Fl_set_box_color)(Fl_Color c);
   FL_EXPORT_C(Fl_Color          ,Fl_box_color)(Fl_Color c);
   FL_EXPORT_C(int               ,Fl_abi_version)();
@@ -265,6 +266,7 @@ EXPORT {
   FL_EXPORT_C(const char*       ,Fl_local_meta)();
   FL_EXPORT_C(const char*       ,Fl_local_alt)();
   FL_EXPORT_C(const char*       ,Fl_local_shift)();
+#endif
 #ifdef __cplusplus
 }
 #endif

--- a/c-src/Fl_DeviceC.cpp
+++ b/c-src/Fl_DeviceC.cpp
@@ -43,10 +43,12 @@ FL_EXPORT_C(void,Fl_Graphics_Driver_set_font_descriptor)(fl_Graphics_Driver grap
   Fl_Font_Descriptor* _d = static_cast<Fl_Font_Descriptor*>(d);
  return (static_cast<Fl_Graphics_Driver*>(graphics_driver))->font_descriptor(_d);
 }
+#if FL_API_VERSION == 10304
 FL_EXPORT_C(int, fl_Graphics_Driver_draw_scaled)(fl_Graphics_Driver graphics_driver, fl_Image i,  int X, int Y, int W, int H)
 {
   return (static_cast<Fl_Graphics_Driver*>(graphics_driver))->draw_scaled(static_cast<Fl_Image*>(i),X,Y,W,H);
 }
+#endif
 FL_EXPORT_C(void,Fl_Graphics_Driver_Destroy)(fl_Graphics_Driver graphics_driver){
  delete (static_cast<Fl_Graphics_Driver*>(graphics_driver));
 }

--- a/c-src/Fl_DeviceC.h
+++ b/c-src/Fl_DeviceC.h
@@ -25,7 +25,9 @@ EXPORT {
   FL_EXPORT_C(Fl_Color, Fl_Graphics_Driver_color)(fl_Graphics_Driver graphics_driver);
   FL_EXPORT_C(fl_Font_Descriptor, Fl_Graphics_Driver_font_descriptor)(fl_Graphics_Driver graphics_driver);
   FL_EXPORT_C(void, Fl_Graphics_Driver_set_font_descriptor)(fl_Graphics_Driver graphics_driver,fl_Font_Descriptor d);
+#if FL_API_VERSION == 10304
   FL_EXPORT_C(int, fl_Graphics_Driver_draw_scaled)(fl_Graphics_Driver graphics_driver, fl_Image i,int X, int Y, int W, int H);
+#endif
   FL_EXPORT_C(void, Fl_Graphics_Driver_Destroy)(fl_Graphics_Driver graphics_driver);
 
   // Fl_Surface_Device

--- a/c-src/Fl_ImageC.cpp
+++ b/c-src/Fl_ImageC.cpp
@@ -147,9 +147,11 @@ EXPORT {
   FL_EXPORT_C(void,Fl_Image_uncache)(fl_Image image){
     return (static_cast<Fl_DerivedImage*>(image))->uncache();
   }
+#if FL_API_VERSION == 10304
   FL_EXPORT_C(int, Fl_Image_fail)(fl_Image image){
     return (static_cast<Fl_DerivedImage*>(image))->fail();
   }
+#endif
 
 #ifdef __cplusplus
 }

--- a/c-src/Fl_ImageC.h
+++ b/c-src/Fl_ImageC.h
@@ -61,7 +61,9 @@ EXPORT {
   FL_EXPORT_C(void,Fl_Image_draw_with)(fl_Image image,int X,int Y,int W,int H);
   FL_EXPORT_C(void, Fl_Image_draw)(fl_Image image,int X, int Y);
   FL_EXPORT_C(void, Fl_Image_uncache)(fl_Image image);
+#if FL_API_VERSION == 10304
   FL_EXPORT_C(int, Fl_Image_fail)(fl_Image image);
+#endif
 #ifdef __cplusplus
 }
 #endif

--- a/c-src/Fl_Menu_C.cpp
+++ b/c-src/Fl_Menu_C.cpp
@@ -615,9 +615,11 @@ EXPORT {
   FL_EXPORT_C(void,Fl_Menu__set_down_color)(fl_Menu_ menu_,unsigned c){
     (static_cast<Fl_DerivedMenu_*>(menu_))->down_color(c);
   }
+#if FL_API_VERSION == 10304
   FL_EXPORT_C(void, Fl_Menu__set_only)(fl_Menu_ menu_, fl_Menu_Item m){
     (static_cast<Fl_DerivedMenu_*>(menu_))->setonly(static_cast<Fl_Menu_Item*>(m));
   }
+#endif
 #ifdef __cplusplus
 }
 #endif

--- a/c-src/Fl_Menu_C.h
+++ b/c-src/Fl_Menu_C.h
@@ -207,7 +207,9 @@ EXPORT {
   FL_EXPORT_C(void, Fl_Menu__set_down_box)(fl_Menu_ menu_, Fl_Boxtype b);
   FL_EXPORT_C(Fl_Color, Fl_Menu__down_color)(fl_Menu_ menu_);
   FL_EXPORT_C(void, Fl_Menu__set_down_color)(fl_Menu_ menu_, unsigned c);
+#if FL_API_VERSION == 10304
   FL_EXPORT_C(void, Fl_Menu__set_only)(fl_Menu_ menu_, fl_Menu_Item m);
+#endif
 #ifdef __cplusplus
 }
 #endif

--- a/src/Graphics/UI/FLTK/LowLevel/FL.chs
+++ b/src/Graphics/UI/FLTK/LowLevel/FL.chs
@@ -157,6 +157,7 @@ module Graphics.UI.FLTK.LowLevel.FL
      setEventDispatch,
      eventText,
      eventLength,
+#if FL_API_VERSION == 10304
      setBoxColor,
      boxColor,
      abiVersion,
@@ -165,6 +166,7 @@ module Graphics.UI.FLTK.LowLevel.FL
      localMeta,
      localAlt,
      localShift
+#endif
     )
 where
 #include "Fl_C.h"
@@ -834,6 +836,7 @@ releaseWidgetPointer :: (Parent a Widget) => Ref a -> IO ()
 releaseWidgetPointer wp = withRef wp {#call Fl_release_widget_pointer as fl_release_widget_pointer #}
 clearWidgetPointer :: (Parent a Widget) => Ref a -> IO ()
 clearWidgetPointer wp = withRef wp {#call Fl_clear_widget_pointer as fl_Clear_Widget_Pointer #}
+#if FL_API_VERSION == 10304
 setBoxColor :: Color -> IO ()
 setBoxColor c = {#call Fl_set_box_color as fl_set_box_color #} (cFromColor c)
 boxColor :: Color -> IO Color
@@ -850,3 +853,4 @@ localMeta :: IO T.Text
 localMeta = {#call Fl_local_meta as fl_local_meta #} >>= cStringToText
 localShift :: IO T.Text
 localShift = {#call Fl_local_shift as fl_local_shift #} >>= cStringToText
+#endif

--- a/src/Graphics/UI/FLTK/LowLevel/Hierarchy.hs
+++ b/src/Graphics/UI/FLTK/LowLevel/Hierarchy.hs
@@ -534,8 +534,10 @@ module Graphics.UI.FLTK.LowLevel.Hierarchy
          setTextcolor,
          DownBox,
          downBox,
+#if FL_API_VERSION == 10304
          SetOnly,
          setOnly,
+#endif
          -- * MenuBar
          MenuBar,
          -- * SysMenuBar
@@ -562,8 +564,10 @@ module Graphics.UI.FLTK.LowLevel.Hierarchy
          drawResize,
          Uncache,
          uncache,
+#if FL_API_VERSION == 10304
          Fail,
          fail,
+#endif
          -- * Bitmap
          Bitmap,
          -- * Pixmap
@@ -2278,8 +2282,13 @@ type MenuPrimFuncs =
   (SetDownBox
   (GetDownColor
   (SetDownColor
+#if FL_API_VERSION == 10304
   (SetOnly
-  ()))))))))))))))))))))))))))))))))))))))))))))))
+#endif
+  ())))))))))))))))))))))))))))))))))))))))))))))
+#if FL_API_VERSION == 10304
+  )
+#endif
 
 type instance Functions MenuPrim = MenuPrimFuncs
 
@@ -2308,7 +2317,9 @@ MAKE_METHOD(SetTextsize,setTextsize)
 MAKE_METHOD(GetTextcolor,getTextcolor)
 MAKE_METHOD(SetTextcolor,setTextcolor)
 MAKE_METHOD(DownBox,downBox)
+#if FL_API_VERSION == 10304
 MAKE_METHOD(SetOnly,setOnly)
+#endif
 
 data CMenuBar parent
 type MenuBar = CMenuBar MenuPrim
@@ -2379,8 +2390,13 @@ type ImageFuncs =
   (DrawResize
   (Draw
   (Uncache
+#if FL_API_VERSION == 10304
   (Fail
-  ()))))))))))))))
+#endif
+  ())))))))))))))
+#if FL_API_VERSION == 10304
+  )
+#endif
 
 type instance Functions Image = ImageFuncs
 
@@ -2392,7 +2408,9 @@ MAKE_METHOD(Inactive,inactive)
 MAKE_METHOD(Desaturate,desaturate)
 MAKE_METHOD(DrawResize,drawResize)
 MAKE_METHOD(Uncache,uncache)
+#if FL_API_VERSION == 10304
 MAKE_METHOD(Fail,fail)
+#endif
 
 data CBitmap parent
 type Bitmap = CBitmap Image

--- a/src/Graphics/UI/FLTK/LowLevel/Image.chs
+++ b/src/Graphics/UI/FLTK/LowLevel/Image.chs
@@ -2,7 +2,9 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Graphics.UI.FLTK.LowLevel.Image
        (
+#if FL_API_VERSION == 10304
        ImageFail(..),
+#endif
        ImageFuncs(..),
        defaultImageFuncs,
        imageNew,
@@ -32,6 +34,7 @@ import Graphics.UI.FLTK.LowLevel.Utils
 import Graphics.UI.FLTK.LowLevel.Hierarchy
 import Graphics.UI.FLTK.LowLevel.Dispatch
 
+#if FL_API_VERSION == 10304
 #c
 enum ImageFail {
   ImageErrNoImage = ERR_NO_IMAGE,
@@ -40,6 +43,7 @@ enum ImageFail {
 };
 #endc
 {#enum ImageFail {} deriving (Show, Eq, Ord) #}
+#endif
 
 type ColorAverageCallback        = Ref Image -> Color -> Float -> IO ()
 type ImageDrawCallback           = Ref Image -> Position -> Size -> Maybe X -> Maybe Y -> IO ()
@@ -181,6 +185,7 @@ instance (impl ~ (Position ->  IO ())) => Op (Draw ()) Image orig impl where
 instance (impl ~ ( IO ())) => Op (Uncache ()) Image orig impl where
   runOp _ _ image = withRef image $ \imagePtr -> uncache' imagePtr
 
+#if FL_API_VERSION == 10304
 {#fun Fl_Image_fail as fail' { id `Ptr ()'} -> `CInt' #}
 instance (impl ~ (IO (Either ImageFail ()))) => Op (Fail ()) Image orig impl where
   runOp _ _ image = withRef image $ \imagePtr -> do
@@ -188,6 +193,7 @@ instance (impl ~ (IO (Either ImageFail ()))) => Op (Fail ()) Image orig impl whe
     if (res == 0)
       then return (Right ())
       else return (Left (cToEnum res))
+#endif
 
 -- $functions
 -- @

--- a/src/Graphics/UI/FLTK/LowLevel/MenuPrim.chs
+++ b/src/Graphics/UI/FLTK/LowLevel/MenuPrim.chs
@@ -297,10 +297,12 @@ instance (impl ~ ( IO (Color))) => Op (GetDownColor ()) MenuPrim orig impl where
 {# fun Fl_Menu__set_down_color as setDownColor' { id `Ptr ()',`Int' } -> `()' #}
 instance (impl ~ (Int ->  IO ())) => Op (SetDownColor ()) MenuPrim orig impl where
   runOp _ _ menu_ c = withRef menu_ $ \menu_Ptr -> setDownColor' menu_Ptr c
+#if FL_API_VERSION == 10304
 {# fun Fl_Menu__set_only as setonly' { id `Ptr ()', id `Ptr ()' } -> `()' #}
 instance (Parent a MenuItem, impl ~ (Ref a -> IO ())) => Op (SetOnly ()) MenuPrim orig impl where
   runOp _ _ menu_ item = withRef menu_ $ \menu_Ptr ->
                             withRef item $ \item_Ptr -> setonly' menu_Ptr item_Ptr
+#endif
 
 -- $functions
 -- @


### PR DESCRIPTION
Was able to compile and run the button example using my standard fltk-1.3.3 that is available on Fedora 25.
Needed to install several development libraries, nothing special: fltk, fltk-devel, fltk-static, libjpeg-turbo-devel, libXcursor-devel, libXinerama-devel.
After this `cabal build`.