### PR TITLE
 Fixed malfunction of setActive.

### DIFF
--- a/c-src/Fl_WidgetC.cpp
+++ b/c-src/Fl_WidgetC.cpp
@@ -379,7 +379,7 @@ FL_EXPORT_C(void, Fl_Widget_draw_label)(fl_Widget Widget){
     return (static_cast<Fl_DerivedWidget*>(widget))->take_focus();
   }
   FL_EXPORT_C(void,Fl_Widget_set_active)(fl_Widget widget){
-    (static_cast<Fl_DerivedWidget*>(widget))->active();
+    (static_cast<Fl_DerivedWidget*>(widget))->set_active();
   }
   FL_EXPORT_C(void,Fl_Widget_clear_active)(fl_Widget widget){
     (static_cast<Fl_DerivedWidget*>(widget))->clear_active();


### PR DESCRIPTION
 Fixed malfunction of setActive in "Graphics.UI.FLTK.LowLevel.Widget".

Widgets should be activated by "setActive".
but FLTKHS calls "int FL_Widget::active()".
