### PR TITLE
flInput and flPassword now return the user's input

### DIFF
--- a/src/Graphics/UI/FLTK/LowLevel/Ask.chs
+++ b/src/Graphics/UI/FLTK/LowLevel/Ask.chs
@@ -38,11 +38,21 @@ flBeep (Just bt) = flBeepType' (fromIntegral (fromEnum bt))
 
 {# fun flc_input as flInput' { unsafeToCString `T.Text' } -> `Maybe T.Text' unsafeFromMaybeCString #}
 flInput :: T.Text -> IO (Maybe T.Text)
-flInput = flInput'
+flInput msg = do
+  r <- flInput' msg
+
+  -- force the result, otherwise multiple calls to 'flInput' may appear to have
+  -- the same result even if the user typed different things
+  r `seq` return r
 
 {# fun flc_password as flPassword' { unsafeToCString `T.Text' } -> `Maybe T.Text' unsafeFromMaybeCString #}
 flPassword :: T.Text -> IO (Maybe T.Text)
-flPassword = flPassword'
+flPassword msg = do
+  r <- flPassword' msg
+
+  -- force the result, otherwise multiple calls to 'flPassword' may appear to have
+  -- the same result even if the user typed different things
+  r `seq` return r
 
 {# fun flc_message as flMessage' { unsafeToCString `T.Text' } -> `()' #}
 flMessage :: T.Text -> IO ()

--- a/src/Graphics/UI/FLTK/LowLevel/Ask.chs
+++ b/src/Graphics/UI/FLTK/LowLevel/Ask.chs
@@ -36,12 +36,12 @@ flBeep :: Maybe BeepType -> IO ()
 flBeep Nothing = flBeep'
 flBeep (Just bt) = flBeepType' (fromIntegral (fromEnum bt))
 
-{# fun flc_input as flInput' { unsafeToCString `T.Text' } -> `()' #}
-flInput :: T.Text -> IO ()
+{# fun flc_input as flInput' { unsafeToCString `T.Text' } -> `T.Text' unsafeFromCString #}
+flInput :: T.Text -> IO T.Text
 flInput = flInput'
 
-{# fun flc_password as flPassword' { unsafeToCString `T.Text' } -> `()' #}
-flPassword :: T.Text -> IO ()
+{# fun flc_password as flPassword' { unsafeToCString `T.Text' } -> `T.Text' unsafeFromCString #}
+flPassword :: T.Text -> IO T.Text
 flPassword = flPassword'
 
 {# fun flc_message as flMessage' { unsafeToCString `T.Text' } -> `()' #}

--- a/src/Graphics/UI/FLTK/LowLevel/Ask.chs
+++ b/src/Graphics/UI/FLTK/LowLevel/Ask.chs
@@ -36,12 +36,12 @@ flBeep :: Maybe BeepType -> IO ()
 flBeep Nothing = flBeep'
 flBeep (Just bt) = flBeepType' (fromIntegral (fromEnum bt))
 
-{# fun flc_input as flInput' { unsafeToCString `T.Text' } -> `T.Text' unsafeFromCString #}
-flInput :: T.Text -> IO T.Text
+{# fun flc_input as flInput' { unsafeToCString `T.Text' } -> `Maybe T.Text' unsafeFromMaybeCString #}
+flInput :: T.Text -> IO (Maybe T.Text)
 flInput = flInput'
 
-{# fun flc_password as flPassword' { unsafeToCString `T.Text' } -> `T.Text' unsafeFromCString #}
-flPassword :: T.Text -> IO T.Text
+{# fun flc_password as flPassword' { unsafeToCString `T.Text' } -> `Maybe T.Text' unsafeFromMaybeCString #}
+flPassword :: T.Text -> IO (Maybe T.Text)
 flPassword = flPassword'
 
 {# fun flc_message as flMessage' { unsafeToCString `T.Text' } -> `()' #}


### PR DESCRIPTION
`flMessage`, `flAlert`, `flInput` and `flPassword` all display a dialog box presenting a text message to the user. `flMessage` and `flAlert` use a slightly different icon hinting at the nature of the message, while `flInput` and `flPassword` both allow the user to type a response. Unfortunately, in fltkhs, all of those functions have type `Text -> IO ()`, meaning that the response typed by the user in the `flInput` and `flPassword` cases is dropped.

This PR changes the types of `flInput` and `flPassword` to `Text -> IO (Maybe Text)`, with `Nothing` being returned if the user cancels the dialog.