### PR TITLE
implement binding for xyToPosition

### DIFF
--- a/c-src/Fl_Text_DisplayC.cpp
+++ b/c-src/Fl_Text_DisplayC.cpp
@@ -74,6 +74,9 @@ EXPORT {
   void Fl_DerivedText_Display::hide_super(){
     Fl_Text_Display::hide();
   }
+  int Fl_DerivedText_Display::xy_to_position(int x,int y,int posType){
+      return Fl_Text_Display::xy_to_position(x,y,posType);
+  }
 
 
 #endif
@@ -636,6 +639,9 @@ EXPORT {
   }
   FL_EXPORT_C(void, Fl_Text_Display_hide_super)(fl_Text_Display o){
     (static_cast<Fl_DerivedText_Display*>(o))->hide_super();
+  }
+  FL_EXPORT_C(int,Fl_Text_Display_xy_to_position)(fl_Text_Display o,int x,int y,int posType){
+    return (static_cast<Fl_DerivedText_Display*>(o))->xy_to_position(x,y,posType);
   }
 
 #ifdef __cplusplus

--- a/c-src/Fl_Text_DisplayC.h
+++ b/c-src/Fl_Text_DisplayC.h
@@ -23,6 +23,7 @@ EXPORT {
     void show_super();
     virtual void hide();
     void hide_super();
+    int xy_to_position(int x,int y,int posType);
     Fl_DerivedText_Display(int X, int Y, int W, int H, const char *l, fl_Widget_Virtual_Funcs* funcs);
     Fl_DerivedText_Display(int X, int Y, int W, int H, fl_Widget_Virtual_Funcs* funcs);
     ~Fl_DerivedText_Display();
@@ -224,6 +225,7 @@ EXPORT {
   FL_EXPORT_C_HEADER(void,Fl_Text_Display_show_super,(fl_Text_Display o));
   FL_EXPORT_C_HEADER(void,Fl_Text_Display_hide,(fl_Text_Display o));
   FL_EXPORT_C_HEADER(void,Fl_Text_Display_hide_super,(fl_Text_Display o));
+  FL_EXPORT_C_HEADER(int,Fl_Text_Display_xy_to_position,(fl_Text_Display o, int x, int y, int posType));
 #ifdef __cplusplus
 }
 #endif

--- a/src/Graphics/UI/FLTK/LowLevel/Hierarchy.hs
+++ b/src/Graphics/UI/FLTK/LowLevel/Hierarchy.hs
@@ -1409,6 +1409,8 @@ module Graphics.UI.FLTK.LowLevel.Hierarchy
          setInsertPosition,
          GetInsertPosition,
          getInsertPosition,
+         XyToPosition,
+         xyToPosition,
          PositionToXy,
          positionToXy,
          InSelection,
@@ -4099,6 +4101,7 @@ type TextDisplayFuncs =
   (Overstrike
   (SetInsertPosition
   (GetInsertPosition
+  (XyToPosition
   (PositionToXy
   (InSelection
   (ShowInsertPosition
@@ -4153,7 +4156,7 @@ type TextDisplayFuncs =
   (Draw
   (ShowWidget
   (ShowWidgetSuper
-  ())))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+  ()))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
 
 type instance Functions TextDisplay = TextDisplayFuncs
 
@@ -4164,6 +4167,7 @@ MAKE_METHOD(Scroll,scroll)
 MAKE_METHOD(Overstrike,overstrike)
 MAKE_METHOD(SetInsertPosition,setInsertPosition)
 MAKE_METHOD(GetInsertPosition,getInsertPosition)
+MAKE_METHOD(XyToPosition,xyToPosition)
 MAKE_METHOD(PositionToXy,positionToXy)
 MAKE_METHOD(InSelection,inSelection)
 MAKE_METHOD(ShowInsertPosition,showInsertPosition)

--- a/src/Graphics/UI/FLTK/LowLevel/TextDisplay.chs
+++ b/src/Graphics/UI/FLTK/LowLevel/TextDisplay.chs
@@ -132,6 +132,13 @@ instance (impl ~ (AtIndex ->  IO ())) => Op (SetInsertPosition ()) TextDisplay o
 {# fun Fl_Text_Display_insert_position as insertPosition' { id `Ptr ()' } -> `Int' #}
 instance (impl ~ ( IO AtIndex)) => Op (GetInsertPosition ()) TextDisplay orig impl where
    runOp _ _ text_display = withRef text_display $ \text_displayPtr -> insertPosition' text_displayPtr >>= return . AtIndex
+{# fun Fl_Text_Display_xy_to_position as xyToPosition' { id `Ptr ()',`Int',`Int',`Int'} -> `Int' #}
+instance (impl ~ (Position -> Maybe PositionType -> IO AtIndex)) => Op (XyToPosition ()) TextDisplay orig impl where
+  runOp _ _ text_display (Position (X x) (Y y)) mPosType =
+    withRef text_display $ \text_displayPtr ->
+    xyToPosition' text_displayPtr x y ((fromIntegral . fromEnum) posType) >>= return . AtIndex
+      where
+        posType = maybe CharacterPos id mPosType
 {# fun Fl_Text_Display_position_to_xy as positionToXy' { id `Ptr ()',`Int', id `Ptr CInt', id `Ptr CInt'} -> `Int' #}
 instance (impl ~ (AtIndex ->  IO (Either OutOfRange Position))) => Op (PositionToXy ()) TextDisplay orig impl where
   runOp _ _ text_display (AtIndex pos)  =


### PR DESCRIPTION
resolve #101 by implementing a binding for xyToPosition to power [this example](https://gist.github.com/plredmond/5e91aab1dff5f7140d71ea2dee63dbe4#file-texteditor-hs) which works just the same as the cpp example on the same page (characters under the cursor change case as the cursor moves around)