### PR TITLE
Add optional default string for flInput.

### DIFF
--- a/src/Graphics/UI/FLTK/LowLevel/Ask.chs
+++ b/src/Graphics/UI/FLTK/LowLevel/Ask.chs
@@ -39,9 +39,9 @@ flBeep (Just bt) = flBeepType' (fromIntegral (fromEnum bt))
 
 {# fun flc_input_with_deflt as flInput' { `CString',`CString' } -> `CString' #}
 flInput :: T.Text -> Maybe T.Text -> IO (Maybe T.Text)
-flInput msg maybeDefault = do
+flInput msg defaultMsg = do
   msgC <- copyTextToCString msg
-  let def = fromMaybe T.empty maybeDefault
+  let def = fromMaybe T.empty defaultMsg
   defaultC <- copyTextToCString def
   r <- flInput' msgC defaultC
   cStringToMaybeText r

--- a/src/Graphics/UI/FLTK/LowLevel/Ask.chs
+++ b/src/Graphics/UI/FLTK/LowLevel/Ask.chs
@@ -15,6 +15,7 @@ where
 import C2HS hiding (cFromEnum, cToBool,cToEnum)
 
 import qualified Data.Text as T
+import Data.Maybe (fromMaybe)
 import Graphics.UI.FLTK.LowLevel.Utils
 
 #c
@@ -36,10 +37,13 @@ flBeep :: Maybe BeepType -> IO ()
 flBeep Nothing = flBeep'
 flBeep (Just bt) = flBeepType' (fromIntegral (fromEnum bt))
 
-{# fun flc_input as flInput' { `CString' } -> `CString' #}
-flInput :: T.Text -> IO (Maybe T.Text)
-flInput msg = do
-  r <- copyTextToCString msg >>= flInput'
+{# fun flc_input_with_deflt as flInput' { `CString',`CString' } -> `CString' #}
+flInput :: T.Text -> Maybe T.Text -> IO (Maybe T.Text)
+flInput msg maybeDefault = do
+  msgC <- copyTextToCString msg
+  let def = fromMaybe T.empty maybeDefault
+  defaultC <- copyTextToCString def
+  r <- flInput' msgC defaultC
   cStringToMaybeText r
 
 {# fun flc_password as flPassword' { `CString' } -> `CString' #}


### PR DESCRIPTION
Apologies if you have a preferred naming scheme for variables; I'm still learning Haskell style.

This adds an optional default string for flInput, without dealing with the complexity of the varargs stuff.  Users can certainly compute their own string before passing it in, so this seems like decent bang for the buck.