### PR TITLE
Add missing linker option indicator on Mac

### DIFF
--- a/c-src/Makefile.in
+++ b/c-src/Makefile.in
@@ -126,7 +126,7 @@ SHARED_OBJECT_FILES = ../shared_object_files
 STATIC_OBJECT_FILES = ../static_object_files
 ifeq ($(shell uname) , Darwin)
 	SHARED_EXT=dylib
-	SONAME_FLAGS=-dynamiclib -install_name
+	SONAME_FLAGS=-dynamiclib -Wl,-install_name
 else
 	SHARED_EXT=so
 	SONAME_FLAGS= -shared -Wl,-soname


### PR DESCRIPTION
This is a change I mentioned here: https://github.com/deech/fltkhs/issues/90#issuecomment-511217196

I'm not quite sure if it is correct but it gets the library to build again for me on Mojave.