### PR TITLE
Add setIconRaw to set window icon to void*

### DIFF
--- a/c-src/Fl_WindowC.cpp
+++ b/c-src/Fl_WindowC.cpp
@@ -764,6 +764,9 @@ FL_EXPORT_C(fl_Window, Fl_OverriddenWindow_NewXY_WithLabel)(int x, int y, int w,
     Fl_RGB_Image* rgb = static_cast<Fl_RGB_Image*>(i);
     (static_cast<Fl_DerivedWindow*>(win))->icon(rgb);
   }
+  FL_EXPORT_C(void,Fl_Window_set_icon_raw)(fl_Window win,const void * ic){
+    (static_cast<Fl_DerivedWindow*>(win))->icon(ic);
+  }
   FL_EXPORT_C(int,Fl_Window_shown)(fl_Window win){
     return (static_cast<Fl_DerivedWindow*>(win))->shown();
   }

--- a/c-src/Fl_WindowC.h
+++ b/c-src/Fl_WindowC.h
@@ -247,6 +247,7 @@ EXPORT {
   FL_EXPORT_C_HEADER(void,Fl_Window_set_xclass,(fl_Window win,const char* c));
   FL_EXPORT_C_HEADER(const void*,Fl_Window_icon,(fl_Window win));
   FL_EXPORT_C_HEADER(void,Fl_Window_set_icon,(fl_Window win,fl_RGB_Image ic));
+  FL_EXPORT_C_HEADER(void,Fl_Window_set_icon_raw,(fl_Window win,const void* ic));
   FL_EXPORT_C_HEADER(int,Fl_Window_shown,(fl_Window win));
   FL_EXPORT_C_HEADER(void,Fl_Window_iconize,(fl_Window win));
   FL_EXPORT_C_HEADER(int,Fl_Window_x_root,(fl_Window win));

--- a/src/Graphics/UI/FLTK/LowLevel/Base/Window.chs
+++ b/src/Graphics/UI/FLTK/LowLevel/Base/Window.chs
@@ -332,6 +332,10 @@ instance (Parent a RGBImage, impl ~ (Maybe( Ref a ) ->  IO ())) => Op (SetIcon (
           Just copyI -> withRef win $ \winPtr -> withRef copyI $ \iPtr -> setIcon' winPtr iPtr
           Nothing -> throwIO (userError "Could not make a copy of icon image")
 
+{# fun Fl_Window_set_icon_raw as setIconRaw' { id `Ptr ()', id `Ptr ()' } -> `()' supressWarningAboutRes #}
+instance (impl ~ (Ptr a -> IO ())) => Op (SetIconRaw ()) WindowBase orig impl where
+  runOp _ _ win bitmapPtr = withRef win $ \winPtr -> setIconRaw' winPtr (castPtr bitmapPtr)
+
 {# fun Fl_Window_shown as shown' { id `Ptr ()' } -> `Bool' toBool #}
 instance (impl ~ ( IO (Bool))) => Op (Shown ()) WindowBase orig impl where
   runOp _ _ win = withRef win $ \winPtr -> shown' winPtr
@@ -559,7 +563,9 @@ instance (impl ~ ( IO ())) => Op (Flush ()) WindowBase orig impl where
 --
 -- setDefaultCursorWithFgBg :: 'Ref' 'WindowBase' -> 'CursorType' -> ('Maybe' 'Color', 'Maybe' 'Color') -> 'IO' ()
 --
--- setIcon:: ('Parent' a 'RGBImage') => 'Ref' 'WindowBase' -> 'Maybe'( 'Ref' a ) -> 'IO' ()
+-- setIcon :: ('Parent' a 'RGBImage') => 'Ref' 'WindowBase' -> 'Maybe' ( 'Ref' a ) -> 'IO' ()
+--
+-- setIconRaw :: 'Ref' 'WindowBase' -> 'Ptr' a -> 'IO' ()
 --
 -- setIconlabel :: 'Ref' 'WindowBase' -> 'T.Text' -> 'IO' ()
 --

--- a/src/Graphics/UI/FLTK/LowLevel/Hierarchy.hs
+++ b/src/Graphics/UI/FLTK/LowLevel/Hierarchy.hs
@@ -327,6 +327,8 @@ module Graphics.UI.FLTK.LowLevel.Hierarchy
          getIcon,
          SetIcon,
          setIcon,
+         SetIconRaw,
+         setIconRaw,
          Shown,
          shown,
          Iconize,
@@ -2036,6 +2038,7 @@ type WindowBaseFuncs =
   (SetDefaultCursor
   (SetDefaultCursorWithFgBg
   (SetIcon
+  (SetIconRaw
   (SetIconlabel
   (SetLabel
   (SetLabelWithIconlabel
@@ -2052,7 +2055,7 @@ type WindowBaseFuncs =
   (SizeRangeWithArgs
   (WaitForExpose
   (Flush
-  ())))))))))))))))))))))))))))))))))))))))))))))))))))))))
+  ()))))))))))))))))))))))))))))))))))))))))))))))))))))))))
 type instance Functions WindowBase = WindowBaseFuncs
 
 data CWindow parent
@@ -2095,6 +2098,7 @@ MAKE_METHOD(GetXclass,getXclass)
 MAKE_METHOD(SetXclass,setXclass)
 MAKE_METHOD(GetIcon,getIcon)
 MAKE_METHOD(SetIcon,setIcon)
+MAKE_METHOD(SetIconRaw,setIconRaw)
 MAKE_METHOD(Shown,shown)
 MAKE_METHOD(Iconize,iconize)
 MAKE_METHOD(GetXRoot,getXRoot)


### PR DESCRIPTION
I know you fixed `setIcon` to take an `RGBImage` in #154, but this readds (with correct type) the version that takes a `void*` as `setIconRaw` (feel free to change, wasn't sure what a good name would be).

This version takes a platform-specific icon format. The reason I'd like it is on Windows, I use this to pass the .ico from the executable itself to be the window icon, which produces a nicer 16x16 small icon than passing my normal large icon file and having FLTK scale it down (.ico on top, scaled larger .png on bottom):

![icon-comparison](https://user-images.githubusercontent.com/1427698/79030982-7dbffe00-7b61-11ea-9cb0-c36415aedcc3.png)

This is done like so (inside appropriate `ifdef`s):

```hs
foreign import ccall "&fl_display" fl_display :: Ptr HINSTANCE

... = do
  disp <- peek fl_display
  icon <- loadIcon (Just disp) $ intPtrToPtr 1
  FL.setIconRaw window icon
````

where `HINSTANCE` and `loadIcon` come from the `Win32` package.

Also I wasn't sure if it makes sense to accept `Ptr a` or `Ptr ()`. I went with the first but it doesn't really make a difference to me.